### PR TITLE
Initial commit for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if __name__ == "__main__":
         maintainer         = 'NetworkX Developers',
         maintainer_email   = 'networkx-discuss@googlegroups.com',
         description        = 'NetworkX Addon to interface with LEMON graph library',
+        packages           = ['nxlemon'],
         libraries          = libraries,
         test_suite         = 'nose.collector',
         tests_require      = ['nose>=0.10.1']

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+from glob import glob
+import os
+import sys
+
+from setuptools import setup, Extension
+from Cython.Build  import cythonize
+
+if sys.argv[-1] == 'setup.py':
+    print('To install, run \'python setup.py install\'')
+
+if sys.version_info[:2] < (2, 7):
+    print(
+        'networkx-lemon requires Python version 2.7 or later' +
+        ' ({}.{} detected).'.format(*sys.version_info[:2]))
+    sys.exit(-1)
+
+libraries = [
+    ('lemon', {'sources': glob('src/lemon/base.cc'),
+               'depends': glob('src/lemon/*.h') +
+                          glob('src/lemon/concepts/*.h') +
+                          glob('src/lemon/bits/*.h'),
+               'include_dirs': ['src']})]
+
+
+if __name__ == "__main__":
+
+    setup(
+        name               = 'networkx-lemon',
+        version            = '1.0',
+        maintainer         = 'NetworkX Developers',
+        maintainer_email   = 'networkx-discuss@googlegroups.com',
+        description        = 'NetworkX Addon to interface with LEMON graph library',
+        libraries          = libraries,
+        test_suite         = 'nose.collector',
+        tests_require      = ['nose>=0.10.1']
+    )


### PR DESCRIPTION
This is the first commit with a basic structure of `setup.py`. We'll start with `nxlemon.classes` package, that's why I've added it here. A new package will accompany the corresponding changes in `setup.py`. 

Having `setup.py` enables `networkx-lemon` for testing, as early as possible. In that way, `networkx-lemon` will follow the method of Test-driven development, which is always a great way of writing a new package.
