### PR TITLE
Remove all lp solver optional dependecies

### DIFF
--- a/src/lemon/config.h
+++ b/src/lemon/config.h
@@ -1,0 +1,22 @@
+#define LEMON_VERSION "1.3.1"
+#define LEMON_HAVE_LONG_LONG 1
+
+/* #undef LEMON_HAVE_LP */
+/* #undef LEMON_HAVE_MIP */
+/* #undef LEMON_HAVE_GLPK */
+/* #undef LEMON_HAVE_CPLEX */
+/* #undef LEMON_HAVE_SOPLEX */
+/* #undef LEMON_HAVE_CLP */
+/* #undef LEMON_HAVE_CBC */
+
+#define _LEMON_CPLEX 1
+#define _LEMON_CLP 2
+#define _LEMON_GLPK 3
+#define _LEMON_SOPLEX 4
+#define _LEMON_CBC 5
+
+/* #undef LEMON_DEFAULT_LP */
+/* #undef LEMON_DEFAULT_MIP */
+
+/* #undef LEMON_USE_PTHREAD */
+/* #undef LEMON_USE_WIN32_THREADS */


### PR DESCRIPTION
Removed ten files from `src/lemon` which used external dependencies for solving LP problems.

Updated the wiki with the changes : https://github.com/networkx/networkx-lemon/wiki/Changes-for-successful-build
