### PR TITLE
Wrap StaticDigraph class

### DIFF
--- a/nxlemon/api/static_graph.pxd
+++ b/nxlemon/api/static_graph.pxd
@@ -1,0 +1,30 @@
+cdef extern from "lemon/static_graph.h" namespace "lemon":
+    cdef cppclass StaticDigraph:
+
+        StaticDigraph()
+
+        Node node(int)
+        Arc arc(int)
+        int index(Node)
+        int index(Arc)
+        int nodeNum()
+        int arcNum()
+
+        void build[Digraph, NodeRefMap, ArcRefMap](Digraph&, NodeRefMap&, ArcRefMap&)
+
+        void build[ArcListIterator](int, ArcListIterator, ArcListIterator)
+
+        void clear()
+
+        cppclass OutArcIt(Arc):
+            OutArcIt()
+            OutArcIt(Invalid)
+            OutArcIt(StaticDigraph&, Node&)
+            OutArcIt(StaticDigraph&, Arc&)
+            OutArcIt& operator++()
+
+            Node baseNode(OutArcIt&)
+            Node runningNode(OutArcIt&)
+            Node baseNode(InArcIt&)
+            Node runningNode(InArcIt&)
+    

--- a/nxlemon/static_graph.pyx
+++ b/nxlemon/static_graph.pyx
@@ -1,0 +1,1 @@
+cimport api.static_graph

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,12 @@ libraries = [
                           glob('src/lemon/bits/*.h'),
                'include_dirs': ['src']})]
 
+ext_modules = cythonize(
+    [Extension('nxlemon.static_graph', ['nxlemon/static_graph.pyx'],
+               include_dirs=['src'],
+               libraries=['lemon'],
+               language='c++')])
+
 
 if __name__ == "__main__":
 
@@ -35,6 +41,7 @@ if __name__ == "__main__":
         maintainer_email   = 'networkx-discuss@googlegroups.com',
         description        = 'NetworkX Addon to interface with LEMON graph library',
         packages           = ['nxlemon'],
+        ext_modules        = ext_modules,
         libraries          = libraries,
         test_suite         = 'nose.collector',
         tests_require      = ['nose>=0.10.1']


### PR DESCRIPTION
Needs `DigraphExtender` class from `lemon/bits/graph_extender.h` to complete the `StaticDigraph` class.
